### PR TITLE
Fix the report query for middleware usage.

### DIFF
--- a/templates/middleware-usage-report.yaml
+++ b/templates/middleware-usage-report.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: metering.openshift.io/v1alpha1
+kind: Report
+metadata:
+  labels:
+    middleware-container-meter: "true"
+  name: middleware-cpu-usage-report
+spec:
+  query: middleware-cpu-usage
+  schedule:
+    period: hourly

--- a/templates/middleware-usage-reportquery.yaml
+++ b/templates/middleware-usage-reportquery.yaml
@@ -18,6 +18,10 @@ spec:
     - name: used_cores
       type: double
   inputs:
+    - name: ReportingStart
+      type: time
+    - name: ReportingEnd
+      type: time
     - default: kube-pod-labels-com-redhat-product
       name: KubePodLabelsComRedHatProductDataSourceName
       type: ReportDataSource
@@ -33,7 +37,7 @@ spec:
     FROM {| dataSourceTableName .Report.Inputs.PodUsageCpuCoresDataSourceName |} as C
     JOIN {| dataSourceTableName .Report.Inputs.KubePodLabelsComRedHatProductDataSourceName |} as L
         ON C.labels['pod_name'] = L.labels['pod']
-    WHERE C."timestamp" >= timestamp '{|.Report.StartPeriod | prestoTimestamp |}'
-        AND C."timestamp" <= timestamp '{| .Report.EndPeriod | prestoTimestamp |}'
+    WHERE C."timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+        AND C."timestamp" <= timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
     GROUP BY C.labels['namespace'], C.labels['pod_name'], L.labels['label_com_redhat_product']
-    ORDER BY project ASC, used_cores DESC
+    ORDER BY namespace ASC, used_cores DESC


### PR DESCRIPTION
This gets us back to previous operation. Also added a scheduled report to gather data.

```
$ curl -H "Authorization: Bearer $RO_TOKEN" -k "https://$METERING_ENDPOINT?namespace=metering-mcm&format=csv&name=middleware-cpu-usage-report-immediate-run"
pod,namespace,product,used_cores
java-2-ltmb8,shadowman,eap,0.000645
```