### PR TITLE
Combine hourly max cpu core per pod usage with hourly pod Red Hat prouct label and hourly pod image to product mapping.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@ __pycache__/
 # C extensions
 *.so
 
+# CSV files
+*.csv
+
+# JSON files
+*.json
+
 # Distribution / packaging
 .Python
 build/

--- a/templates/middleware-usage-reportquery.yaml
+++ b/templates/middleware-usage-reportquery.yaml
@@ -17,6 +17,9 @@ spec:
       type: varchar
     - name: used_cores
       type: double
+    - name: interval_start
+      type: timestamp
+      unit: date
   inputs:
     - name: ReportingStart
       type: time
@@ -25,19 +28,93 @@ spec:
     - default: kube-pod-labels-com-redhat-product
       name: KubePodLabelsComRedHatProductDataSourceName
       type: ReportDataSource
+    - default: kube-pod-container-info-redhat-image
+      name: KubePodContainerInfoRedHatImageDataSourceName
+      type: ReportDataSource
+    - default: image-product-map
+      name: ImageProductMapDataSourceName
+      type: ReportDataSource
     - default: pod-usage-cpu-cores
       name: PodUsageCpuCoresDataSourceName
       type: ReportDataSource
   query: |
+    WITH cte_hourly_pod_max_cpu_core AS (
+      SELECT
+          C.labels['pod_name'] as pod,
+          C.labels['namespace'] as namespace,
+          max(C.amount) as used_cores,
+          date_trunc('hour', C."timestamp") as interval_start
+      FROM {| dataSourceTableName .Report.Inputs.PodUsageCpuCoresDataSourceName |} as C
+      WHERE C."timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+          AND C."timestamp" <= timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+          AND C.dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+          AND C.dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
+      GROUP BY C.labels['namespace'], C.labels['pod_name'], date_trunc('hour', C."timestamp")
+    ),
+    cte_hourly_pod_by_product_label AS (
+      SELECT
+          L.labels['pod'] as pod,
+          L.labels['namespace'] as namespace,
+          L.labels['label_com_redhat_product'] as product,
+          date_trunc('hour', L."timestamp") as interval_start
+      FROM {| dataSourceTableName .Report.Inputs.KubePodLabelsComRedHatProductDataSourceName |} as L
+      WHERE L."timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+          AND L."timestamp" <= timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+          AND L.dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+          AND L.dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
+      GROUP BY L.labels['namespace'], L.labels['pod'], L.labels['label_com_redhat_product'], date_trunc('hour', L."timestamp")
+    ),
+    cte_hourly_pod_by_image AS (
+      SELECT
+          P.labels['pod'] as pod,
+          P.labels['namespace'] as namespace,
+          P.labels['image'] as image,
+          date_trunc('hour', P."timestamp") as interval_start
+      FROM {| dataSourceTableName .Report.Inputs.KubePodContainerInfoRedHatImageDataSourceName |} as P
+      WHERE P."timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
+          AND P."timestamp" <= timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
+          AND P.dt >= '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prometheusMetricPartitionFormat |}'
+          AND P.dt <= '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prometheusMetricPartitionFormat |}'
+      GROUP BY P.labels['namespace'], P.labels['pod'], P.labels['image'], date_trunc('hour', P."timestamp")
+    ),
+    cte_hourly_pod_max_cpu_core_by_label AS (
+      SELECT
+        C.pod,
+        C.namespace,
+        L.product,
+        C.used_cores,
+        C.interval_start
+      FROM cte_hourly_pod_max_cpu_core as C
+      JOIN cte_hourly_pod_by_product_label as L
+        ON C.pod = L.pod
+          AND C.interval_start = L.interval_start
+    ),
+    cte_hourly_pod_max_cpu_core_by_image AS (
+      SELECT
+        C.pod,
+        C.namespace,
+        P.product,
+        C.used_cores,
+        C.interval_start
+      FROM cte_hourly_pod_max_cpu_core as C
+      JOIN cte_hourly_pod_by_image as I
+        ON C.pod = I.pod
+          AND C.interval_start = I.interval_start
+      JOIN {| dataSourceTableName .Report.Inputs.ImageProductMapDataSourceName |} as P
+          ON I.image = P.image
+    )
     SELECT
-        C.labels['pod_name'] as pod,
-        C.labels['namespace'] as namespace,
-        L.labels['label_com_redhat_product'] as product,
-        max(C.amount) as used_cores
-    FROM {| dataSourceTableName .Report.Inputs.PodUsageCpuCoresDataSourceName |} as C
-    JOIN {| dataSourceTableName .Report.Inputs.KubePodLabelsComRedHatProductDataSourceName |} as L
-        ON C.labels['pod_name'] = L.labels['pod']
-    WHERE C."timestamp" >= timestamp '{| default .Report.ReportingStart .Report.Inputs.ReportingStart | prestoTimestamp |}'
-        AND C."timestamp" <= timestamp '{| default .Report.ReportingEnd .Report.Inputs.ReportingEnd | prestoTimestamp |}'
-    GROUP BY C.labels['namespace'], C.labels['pod_name'], L.labels['label_com_redhat_product']
-    ORDER BY namespace ASC, used_cores DESC
+      pod,
+      namespace,
+      product,
+      used_cores,
+      interval_start
+    FROM cte_hourly_pod_max_cpu_core_by_label
+    UNION ALL
+    SELECT
+      pod,
+      namespace,
+      product,
+      used_cores,
+      interval_start
+    FROM cte_hourly_pod_max_cpu_core_by_image

--- a/templates/middleware-usage-reportquery.yaml
+++ b/templates/middleware-usage-reportquery.yaml
@@ -96,6 +96,7 @@ spec:
       FROM cte_hourly_pod_max_cpu_core as C
       JOIN cte_hourly_pod_by_product_label as L
         ON C.pod = L.pod
+          AND C.namespace = L.namespace
           AND C.interval_start = L.interval_start
       JOIN {| dataSourceTableName .Report.Inputs.ProductCpuCorePricingDataSourceName |} as D
           ON L.product = D.product

--- a/templates/middleware-usage-reportquery.yaml
+++ b/templates/middleware-usage-reportquery.yaml
@@ -17,6 +17,10 @@ spec:
       type: varchar
     - name: used_cores
       type: double
+    - name: cost_per_hour
+      type: double
+    - name: currency
+      type: varchar
     - name: interval_start
       type: timestamp
       unit: date
@@ -33,6 +37,9 @@ spec:
       type: ReportDataSource
     - default: image-product-map
       name: ImageProductMapDataSourceName
+      type: ReportDataSource
+    - default: product-cpu-core-pricing
+      name: ProductCpuCorePricingDataSourceName
       type: ReportDataSource
     - default: pod-usage-cpu-cores
       name: PodUsageCpuCoresDataSourceName
@@ -83,11 +90,15 @@ spec:
         C.namespace,
         L.product,
         C.used_cores,
+        C.used_cores * D.cost_per_cpu_core_hour as cost_per_hour,
+        D.currency,
         C.interval_start
       FROM cte_hourly_pod_max_cpu_core as C
       JOIN cte_hourly_pod_by_product_label as L
         ON C.pod = L.pod
           AND C.interval_start = L.interval_start
+      JOIN {| dataSourceTableName .Report.Inputs.ProductCpuCorePricingDataSourceName |} as D
+          ON L.product = D.product
     ),
     cte_hourly_pod_max_cpu_core_by_image AS (
       SELECT
@@ -95,6 +106,8 @@ spec:
         C.namespace,
         P.product,
         C.used_cores,
+        C.used_cores * D.cost_per_cpu_core_hour as cost_per_hour,
+        D.currency,
         C.interval_start
       FROM cte_hourly_pod_max_cpu_core as C
       JOIN cte_hourly_pod_by_image as I
@@ -102,12 +115,16 @@ spec:
           AND C.interval_start = I.interval_start
       JOIN {| dataSourceTableName .Report.Inputs.ImageProductMapDataSourceName |} as P
           ON I.image = P.image
+      JOIN {| dataSourceTableName .Report.Inputs.ProductCpuCorePricingDataSourceName |} as D
+          ON P.product = D.product
     )
     SELECT
       pod,
       namespace,
       product,
       used_cores,
+      cost_per_hour,
+      currency,
       interval_start
     FROM cte_hourly_pod_max_cpu_core_by_label
     UNION ALL
@@ -116,5 +133,7 @@ spec:
       namespace,
       product,
       used_cores,
+      cost_per_hour,
+      currency,
       interval_start
     FROM cte_hourly_pod_max_cpu_core_by_image

--- a/templates/middleware-usage-reportquery.yaml
+++ b/templates/middleware-usage-reportquery.yaml
@@ -112,6 +112,7 @@ spec:
       FROM cte_hourly_pod_max_cpu_core as C
       JOIN cte_hourly_pod_by_image as I
         ON C.pod = I.pod
+          AND C.namespace = l.namespace
           AND C.interval_start = I.interval_start
       JOIN {| dataSourceTableName .Report.Inputs.ImageProductMapDataSourceName |} as P
           ON I.image = P.image

--- a/templates/product-cpu-core-pricing-prestotable.yaml
+++ b/templates/product-cpu-core-pricing-prestotable.yaml
@@ -18,6 +18,8 @@ spec:
   createTableAs: true
   query: |
     SELECT * FROM (
-      VALUES ('rhpam73', 0.1149, 'USD'),
-             ('amq7', 0.0928, 'USD')
+      VALUES ('rhpam73', 0.45, 'USD'),
+             ('amq7', 0.39, 'USD'),
+             ('eap', 0.26, 'USD'),
+             ('eap7', 0.26, 'USD')
     ) AS t (product, cost_per_cpu_core_hour, currency)


### PR DESCRIPTION
Result of an immediate-run report (see attached CSV text file):
[prod_cpu_cores.txt](https://github.com/chambridge/middleware-container-meter/files/3277348/prod_cpu_cores.txt)

